### PR TITLE
ログ作成/編集時にMarkdown以外の記法を追加

### DIFF
--- a/src/app/api/guest/merge/route.ts
+++ b/src/app/api/guest/merge/route.ts
@@ -13,6 +13,7 @@ const DraftSchema = z.object({
   tags: z.array(z.string()).optional(),
   updatedAt: z.string().optional(),
   createdAt: z.string().optional(),
+  format: z.enum(['plain', 'markdown']).optional(),
 });
 
 const BodySchema = z.object({
@@ -27,6 +28,7 @@ type BulkDoc = {
   createdAt: Date;
   updatedAt: Date;
   guestTempId: string;
+  format: 'plain' | 'markdown';
 };
 
 function isRequestLike(obj: unknown): obj is { json: () => Promise<unknown> } {
@@ -102,6 +104,7 @@ export async function POST(req: Request) {
         createdAt: d.createdAt ? new Date(d.createdAt) : new Date(),
         updatedAt: d.updatedAt ? new Date(d.updatedAt) : new Date(),
         guestTempId: d.tempId,
+        format: d.format ?? 'plain',
       };
 
       return {

--- a/src/app/api/logs/[id]/route.ts
+++ b/src/app/api/logs/[id]/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { connectToDatabase } from '@/lib/mongodb';
-import { Log } from '@/models/Log';
+import { Log as LogModel } from '@/models/Log';
 import { z } from 'zod';
 import { getServerToken } from '@/lib/auth';
 
@@ -10,53 +10,43 @@ const updateSchema = z
     content: z.string().min(1).optional(),
     tags: z.array(z.string()).optional(),
     date: z.string().optional(),
+    format: z.enum(['plain', 'markdown']).optional(),
   })
-  // 空オブジェクトを無効にする（少なくとも 1 フィールドが必要）
   .refine(obj => Object.keys(obj).length > 0, {
     message: 'At least one field must be provided',
   });
 
 async function resolveIdFromContext(context?: unknown): Promise<string | undefined> {
   if (!context) return undefined;
-
   const maybeParams = (context as { params?: unknown }).params;
   if (maybeParams === undefined) return undefined;
-
   const paramsObj = (await Promise.resolve(maybeParams)) as { id?: string } | undefined;
   return paramsObj?.id;
 }
 
-// GET
 export async function GET(_req: Request, context?: unknown) {
   const token = await getServerToken(_req);
-  if (!token?.sub) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  }
+  if (!token?.sub) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
   const id = await resolveIdFromContext(context);
   if (!id) return NextResponse.json({ error: 'Missing id' }, { status: 400 });
 
   await connectToDatabase();
-  const log = await Log.findById(id).lean();
-  if (!log || log.userId !== token.sub) {
+  const log = await LogModel.findById(id).lean();
+  if (!log || log.userId !== token.sub)
     return NextResponse.json({ error: 'Not found' }, { status: 404 });
-  }
 
   return NextResponse.json(log);
 }
 
-// PUT
 export async function PUT(req: Request, context?: unknown) {
   const token = await getServerToken(req);
-  if (!token?.sub) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  }
+  if (!token?.sub) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
   const id = await resolveIdFromContext(context);
   if (!id) return NextResponse.json({ error: 'Missing id' }, { status: 400 });
 
   const body = await req.json().catch(() => ({}));
-
   const parsed = updateSchema.safeParse(body);
   if (!parsed.success) {
     return NextResponse.json(
@@ -66,36 +56,32 @@ export async function PUT(req: Request, context?: unknown) {
   }
 
   await connectToDatabase();
-  const existing = await Log.findById(id);
-  if (!existing || existing.userId !== token.sub) {
+  const existing = await LogModel.findById(id);
+  if (!existing || existing.userId !== token.sub)
     return NextResponse.json({ error: 'Not found' }, { status: 404 });
-  }
 
   if (parsed.data.title !== undefined) existing.title = parsed.data.title;
   if (parsed.data.content !== undefined) existing.content = parsed.data.content;
   if (parsed.data.tags !== undefined) existing.tags = parsed.data.tags;
   if (parsed.data.date !== undefined) existing.date = new Date(parsed.data.date);
+  if (parsed.data.format !== undefined) existing.format = parsed.data.format;
 
   await existing.save();
   return NextResponse.json(existing);
 }
 
-// DELETE
 export async function DELETE(_req: Request, context?: unknown) {
   const token = await getServerToken(_req);
-  if (!token?.sub) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  }
+  if (!token?.sub) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
   const id = await resolveIdFromContext(context);
   if (!id) return NextResponse.json({ error: 'Missing id' }, { status: 400 });
 
   await connectToDatabase();
-  const existing = await Log.findById(id);
-  if (!existing || existing.userId !== token.sub) {
+  const existing = await LogModel.findById(id);
+  if (!existing || existing.userId !== token.sub)
     return NextResponse.json({ error: 'Not found' }, { status: 404 });
-  }
 
-  await Log.findByIdAndDelete(id);
+  await LogModel.findByIdAndDelete(id);
   return NextResponse.json({ message: 'Deleted' });
 }

--- a/src/app/api/logs/route.ts
+++ b/src/app/api/logs/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { connectToDatabase } from '@/lib/mongodb';
-import { Log } from '@/models/Log';
+import { Log as LogModel } from '@/models/Log';
 import { z } from 'zod';
 import { getServerToken } from '@/lib/auth';
 
@@ -9,24 +9,23 @@ const createSchema = z.object({
   content: z.string().min(1),
   tags: z.array(z.string()).optional(),
   date: z.string().optional(),
+  format: z.enum(['plain', 'markdown']).optional(),
 });
 
 export async function GET(req: Request) {
   const token = await getServerToken(req);
-  if (!token?.sub)
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  if (!token?.sub) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
   await connectToDatabase();
-  const logs = await Log.find({ userId: token.sub }).sort({ date: -1 }).lean();
+  const logs = await LogModel.find({ userId: token.sub }).sort({ date: -1 }).lean();
   return NextResponse.json(logs);
 }
 
 export async function POST(req: Request) {
   const token = await getServerToken(req);
-  if (!token?.sub)
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  if (!token?.sub) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
-  const body = await req.json();
+  const body = await req.json().catch(() => ({}));
   const parsed = createSchema.safeParse(body);
   if (!parsed.success) {
     return NextResponse.json(
@@ -37,12 +36,13 @@ export async function POST(req: Request) {
 
   await connectToDatabase();
 
-  const log = new Log({
+  const log = new LogModel({
     title: parsed.data.title,
     content: parsed.data.content,
     date: parsed.data.date ? new Date(parsed.data.date) : new Date(),
-    tags: parsed.data.tags || [],
+    tags: parsed.data.tags ?? [],
     userId: token.sub,
+    format: parsed.data.format ?? 'plain',
   });
 
   await log.save();

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,1 +1,180 @@
 @import 'tailwindcss';
+
+.prose,
+.article-prose {
+  max-width: none; /* 幅制限しない */
+  color: #111827; /* テキスト色 */
+  line-height: 1.7;
+  font-weight: 400;
+  font-family: ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, 'Helvetica Neue', Arial;
+}
+
+/* 見出し */
+.prose h1,
+.article-prose h1 {
+  font-size: 1.875rem; /* 30px */
+  line-height: 1.15;
+  margin: 1.05rem 0 0.45rem 0;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  text-transform: none; /* 大文字化されている場合を無効化 */
+}
+
+.prose h2,
+.article-prose h2 {
+  font-size: 1.5rem; /* 24px */
+  margin: 0.9rem 0 0.45rem 0;
+  font-weight: 700;
+  text-transform: none;
+}
+
+.prose h3,
+.article-prose h3 {
+  font-size: 1.25rem; /* 20px */
+  margin: 0.8rem 0 0.4rem 0;
+  font-weight: 600;
+  text-transform: none;
+}
+
+/* 段落 */
+.prose p,
+.article-prose p {
+  margin: 0.6rem 0;
+  color: inherit;
+  line-height: 1.7;
+}
+
+/* リスト（丸・番号） */
+.prose ul,
+.article-prose ul {
+  list-style: disc;
+  margin: 0.6rem 0;
+  padding-left: 1.4rem; /* マーカーのスペース */
+}
+
+.prose ol,
+.article-prose ol {
+  list-style: decimal;
+  margin: 0.6rem 0;
+  padding-left: 1.6rem;
+}
+
+.prose li,
+.article-prose li {
+  margin: 0.25rem 0;
+  /* marker のスタイル（ブラウザ互換）*/
+}
+
+.prose ul li::marker,
+.article-prose ul li::marker {
+  font-weight: 600;
+  color: inherit;
+}
+
+/* テーブル */
+.prose table,
+.article-prose table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 0.75rem 0;
+  overflow: auto;
+  display: table;
+}
+
+.prose th,
+.article-prose th,
+.prose td,
+.article-prose td {
+  border: 1px solid #4b5563; /* 薄いグレーの罫線 */
+  padding: 0.5rem 0.75rem;
+  text-align: left;
+  vertical-align: top;
+}
+
+.prose thead th,
+.article-prose thead th {
+  background: #d3d3d3;
+  font-weight: 700;
+}
+
+/* ブロック引用 */
+.prose blockquote,
+.article-prose blockquote {
+  border-left: 4px solid #e5e7eb;
+  margin: 0.8rem 0;
+  padding-left: 1rem;
+  color: #4b5563;
+  background: rgba(229, 231, 235, 0.15);
+}
+
+/* コードブロック / インラインコード */
+.prose pre,
+.article-prose pre {
+  background: #0f172a; /* 濃い背景 */
+  color: #4682b4;
+  padding: 1rem;
+  border-radius: 0.375rem;
+  overflow: auto;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, 'Roboto Mono', monospace;
+  font-size: 0.9rem;
+  margin: 0.75rem 0;
+}
+
+.prose code,
+.article-prose code {
+  padding: 0.15rem 0.35rem;
+  border-radius: 0.25rem;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, 'Roboto Mono', monospace;
+  font-size: 0.92em;
+}
+
+/* 画像のレスポンシブ化 */
+.prose img,
+.article-prose img {
+  max-width: 100%;
+  height: auto;
+}
+
+/* テーブルの横スクロール(狭い画面用) */
+.prose table,
+.article-prose table {
+  display: block;
+  width: 100%;
+  overflow: auto;
+}
+
+/* リンク */
+.prose a,
+.article-prose a {
+  color: #2563eb; /* 青系 */
+  text-decoration: underline; /* 下線 */
+  word-break: break-word; /* 長いURLも折り返す */
+  cursor: pointer;
+}
+
+.prose a:hover,
+.article-prose a:hover {
+  color: #1d4ed8; /* 濃い青 */
+}
+
+/* ダークモード（ブラウザ preference に依存） */
+/* @media (prefers-color-scheme: dark) {
+  .prose,
+  .article-prose {
+    color: #e6eef6;
+  }
+  .prose th,
+  .article-prose th,
+  .prose td,
+  .article-prose td {
+    border-color: #374151;
+  }
+  .prose thead th,
+  .article-prose thead th {
+    background: #111827;
+  }
+  .prose pre,
+  .article-prose pre {
+    background: #071024;
+  }
+} */

--- a/src/app/logs/edit/[id]/page.tsx
+++ b/src/app/logs/edit/[id]/page.tsx
@@ -1,6 +1,6 @@
 import EditLog from '@/components/EditLog';
 import { connectToDatabase } from '@/lib/mongodb';
-import { Log } from '@/models/Log';
+import { Log as LogModel } from '@/models/Log';
 import { notFound } from 'next/navigation';
 
 type PageProps = {
@@ -11,11 +11,11 @@ export default async function EditLogPage({ params }: PageProps) {
   const resolved = await params;
   const id = resolved?.id;
   if (!id) {
-    notFound(); // id が無ければ 404
+    notFound();
   }
 
   await connectToDatabase();
-  const log = await Log.findById(id).lean();
+  const log = await LogModel.findById(id).lean();
 
   if (!log) {
     notFound();
@@ -30,6 +30,8 @@ export default async function EditLogPage({ params }: PageProps) {
         ? log.date.toISOString()
         : new Date(log.date ?? Date.now()).toISOString(),
     tags: Array.isArray(log.tags) ? log.tags : [],
+    format: (log.format as 'plain' | 'markdown') ?? 'plain',
+    userId: typeof log.userId === 'string' ? log.userId : undefined,
   };
 
   return <EditLog log={serializedLog} />;

--- a/src/app/logs/new/page.tsx
+++ b/src/app/logs/new/page.tsx
@@ -1,8 +1,10 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
 import { createGuestDraft } from '@/lib/guestStorage';
 
 export default function NewLogPage() {
@@ -12,30 +14,42 @@ export default function NewLogPage() {
   const [title, setTitle] = useState('');
   const [content, setContent] = useState('');
   const [tagsText, setTagsText] = useState('');
+  const [format, setFormat] = useState<'plain' | 'markdown'>('plain'); // 新規のデフォルトはテキスト
   const [loading, setLoading] = useState(false);
+
+  // プレビュー表示状態（Markdown を選択している時のみ利用可能）
+  const [showPreview, setShowPreview] = useState(false);
 
   const isAuthenticated = status === 'authenticated' && !!session;
   const isSessionLoading = status === 'loading';
-  const clientGuestFlag =
-    typeof window !== 'undefined' && localStorage.getItem('guest_access') === 'true';
-  const isGuestViewing = !isAuthenticated && clientGuestFlag;
+
+  // フォーマットが plain に変わったらプレビューを自動的に閉じる
+  useEffect(() => {
+    if (format !== 'markdown' && showPreview) {
+      setShowPreview(false);
+    }
+  }, [format, showPreview]);
+
+  const tags = useMemo(
+    () =>
+      tagsText
+        .split(',')
+        .map(t => t.trim())
+        .filter(Boolean),
+    [tagsText]
+  );
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     if (isSessionLoading) return;
     setLoading(true);
 
-    const tags = tagsText
-      .split(',')
-      .map(t => t.trim())
-      .filter(Boolean);
-
     try {
       if (isAuthenticated) {
         const res = await fetch('/api/logs', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ title, content, tags }),
+          body: JSON.stringify({ title, content, tags, format }),
         });
 
         if (!res.ok) {
@@ -48,24 +62,13 @@ export default function NewLogPage() {
           throw new Error(errText || '作成に失敗しました');
         }
         router.push('/logs');
-      } else if (isGuestViewing) {
-        // ゲストの場合はローカルに保存
-        try {
-          localStorage.setItem('guest_access', 'true');
-        } catch (e) {
-          console.warn('failed to set guest_access', e);
-        }
-
-        createGuestDraft({ title: title || 'Untitled', content, tags });
-        router.push('/logs');
       } else {
-        // 未ログイン(next-auth のセッションがない)かつ未ゲスト(guest_access キーが存在しない)の場合：自動的にゲスト保存してログ一覧へ
         try {
           localStorage.setItem('guest_access', 'true');
         } catch (e) {
           console.warn('failed to set guest_access', e);
         }
-        createGuestDraft({ title: title || 'Untitled', content, tags });
+        createGuestDraft({ title: title || 'Untitled', content, tags, format });
         router.push('/logs');
       }
     } catch (err) {
@@ -75,6 +78,9 @@ export default function NewLogPage() {
       setLoading(false);
     }
   }
+
+  // レイアウト用のクラス（プレビュー時は2カラム風）
+  const containerClass = showPreview ? 'grid grid-cols-1 lg:grid-cols-2 gap-6' : 'w-full';
 
   return (
     <main>
@@ -92,44 +98,109 @@ export default function NewLogPage() {
           />
         </div>
 
-        <div>
-          <label className="block text-sm mb-1">内容（Markdown対応）</label>
-          <textarea
-            value={content}
-            onChange={e => setContent(e.target.value)}
-            rows={10}
-            required
-            className="w-full rounded-md border px-3 py-2"
-            placeholder="本文..."
-          />
-        </div>
+        <div className={containerClass}>
+          <div>
+            <div>
+              <label className="block text-sm mb-1">記法</label>
+              <div className="flex gap-3 items-center mb-2">
+                <label className="inline-flex items-center gap-2">
+                  <input
+                    type="radio"
+                    name="format"
+                    value="plain"
+                    checked={format === 'plain'}
+                    onChange={() => setFormat('plain')}
+                  />
+                  <span>テキスト</span>
+                </label>
+                <label className="inline-flex items-center gap-2">
+                  <input
+                    type="radio"
+                    name="format"
+                    value="markdown"
+                    checked={format === 'markdown'}
+                    onChange={() => setFormat('markdown')}
+                  />
+                  <span>Markdown</span>
+                </label>
+              </div>
+            </div>
 
-        <div>
-          <label className="block text-sm mb-1">タグ（カンマ区切り）</label>
-          <input
-            value={tagsText}
-            onChange={e => setTagsText(e.target.value)}
-            className="w-full rounded-md border px-3 py-2"
-            placeholder="nextjs, mongodb"
-          />
-        </div>
+            <div>
+              <label className="block text-sm mb-1">内容</label>
+              <textarea
+                value={content}
+                onChange={e => setContent(e.target.value)}
+                rows={10}
+                required
+                className="w-full rounded-md border px-3 py-2"
+                placeholder="本文..."
+              />
+            </div>
 
-        <div className="flex gap-3">
-          <button
-            type="submit"
-            disabled={loading || isSessionLoading}
-            className="px-4 py-2 bg-blue-600 text-white rounded-md disabled:opacity-50"
-          >
-            {loading ? '作成中…' : '作成'}
-          </button>
+            <div className="mt-3">
+              <label className="block text-sm mb-1">タグ（カンマ区切り）</label>
+              <input
+                value={tagsText}
+                onChange={e => setTagsText(e.target.value)}
+                className="w-full rounded-md border px-3 py-2"
+                placeholder="タグ１, タグ２..."
+              />
+            </div>
 
-          <button
-            type="button"
-            onClick={() => router.push('/logs')}
-            className="px-4 py-2 border rounded-md"
-          >
-            キャンセル
-          </button>
+            <div className="mt-4 flex gap-3 items-center">
+              <button
+                type="submit"
+                disabled={loading || isSessionLoading}
+                className="px-4 py-2 bg-blue-600 text-white rounded-md disabled:opacity-50"
+              >
+                {loading ? '作成中…' : '作成'}
+              </button>
+
+              <button
+                type="button"
+                onClick={() => router.push('/logs')}
+                className="px-4 py-2 border rounded-md"
+              >
+                キャンセル
+              </button>
+
+              {/* プレビューボタン（Markdown 選択時のみ表示） */}
+              {format === 'markdown' && (
+                <button
+                  type="button"
+                  onClick={() => setShowPreview(s => !s)}
+                  className="px-4 py-2 border rounded-md"
+                >
+                  {showPreview ? 'プレビューを閉じる' : 'プレビューを表示'}
+                </button>
+              )}
+            </div>
+          </div>
+
+          {/* プレビュー画面（format === 'markdown' かつ showPreview が true のときだけ表示） */}
+          {showPreview && format === 'markdown' && (
+            <div className="bg-white rounded-lg p-6 shadow">
+              <div className="flex items-center justify-between mb-3">
+                <h2 className="text-lg font-semibold">プレビュー</h2>
+                <span className="text-sm text-gray-500">Markdown 表示</span>
+              </div>
+
+              <article className="prose article-prose max-w-none">
+                <h3>{title || '（タイトル）'}</h3>
+                <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                  {content || '（Markdown本文）'}
+                </ReactMarkdown>
+                <div className="mt-3">
+                  {tags.map(t => (
+                    <span key={t} className="text-xs bg-gray-100 px-2 py-1 mr-2 rounded">
+                      #{t}
+                    </span>
+                  ))}
+                </div>
+              </article>
+            </div>
+          )}
         </div>
       </form>
     </main>

--- a/src/app/logs/page.tsx
+++ b/src/app/logs/page.tsx
@@ -15,6 +15,9 @@ type ServerLogShape = {
   content: string;
   date: string;
   tags?: string[];
+  format?: 'plain' | 'markdown';
+  userId?: string;
+  guestTempId?: string;
 };
 
 export default function LogsPage() {
@@ -45,6 +48,8 @@ export default function LogsPage() {
       content: item.content,
       date: item.date ?? new Date().toISOString(),
       tags: item.tags ?? [],
+      format: item.format ?? 'plain',
+      _isGuest: !!item.guestTempId && !item.userId,
     };
   }
 
@@ -89,6 +94,7 @@ export default function LogsPage() {
           content: d.content ?? '',
           date: d.updatedAt ?? d.createdAt ?? new Date().toISOString(),
           tags: d.tags ?? [],
+          format: d.format ?? 'plain',
           _isGuest: true,
         }));
         setLogs(mapped);
@@ -147,6 +153,7 @@ export default function LogsPage() {
           content: g.content ?? '',
           date: g.updatedAt ?? g.createdAt ?? new Date().toISOString(),
           tags: g.tags ?? [],
+          format: g.format ?? 'plain',
           _isGuest: true,
         });
         setModalOpen(true);
@@ -166,6 +173,7 @@ export default function LogsPage() {
           content: data.content,
           date: data.date ?? new Date().toISOString(),
           tags: data.tags ?? [],
+          format: data.format ?? 'plain',
         };
         setSelectedLog(fetched);
         setModalOpen(true);
@@ -178,7 +186,7 @@ export default function LogsPage() {
 
   const openLog = (log: LogType) => {
     // URL に反映してモーダルを開く
-    router.replace(`/logs?open=${log._id}`);
+    router.replace(`/logs?open=${encodeURIComponent(log._id)}`);
     setSelectedLog(log);
     setModalOpen(true);
   };
@@ -239,7 +247,8 @@ export default function LogsPage() {
   return (
     <div>
       <header className="mb-6 flex items-center justify-between">
-        <h1 className="text-2xl font-bold">
+        <h1 className="text-2xl font-bold">NoteArc</h1>
+        <h2 className="text-2xl font-bold">
           {isAuthenticated
             ? session.user?.name
               ? `${session.user.name}さんの学習ログ`
@@ -247,7 +256,7 @@ export default function LogsPage() {
             : isGuestViewing
             ? 'ゲスト'
             : '学習ログ'}
-        </h1>
+        </h2>
 
         <div className="flex items-center gap-3">
           {isAuthenticated ? (
@@ -356,7 +365,8 @@ export default function LogsPage() {
               <div className="flex items-center justify-between">
                 <h3 className="text-lg font-medium">{log.title}</h3>
                 <div className="text-xs text-gray-500 whitespace-nowrap">
-                  {new Date(log.date).toLocaleDateString()}
+                  {new Date(log.date).toLocaleDateString()} ・{' '}
+                  {log.format === 'markdown' ? 'Markdown' : 'テキスト'}
                 </div>
               </div>
               <div className="mt-3 flex gap-2 flex-wrap">

--- a/src/components/EditLog.tsx
+++ b/src/components/EditLog.tsx
@@ -2,15 +2,17 @@
 import React, { useEffect, useRef, useState, useMemo } from 'react';
 import { useRouter } from 'next/navigation';
 import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
 import ConfirmDialog from './ConfirmDialog';
 import { getGuestDrafts, saveGuestDraft, removeGuestDraft } from '@/lib/guestStorage';
 
-type Log = {
+type LogType = {
   _id: string;
   title: string;
   content: string;
   date: string;
   tags: string[];
+  format?: 'plain' | 'markdown';
   _isGuest?: boolean;
 };
 
@@ -21,12 +23,13 @@ function parseTags(text: string): string[] {
     .filter(Boolean);
 }
 
-export default function EditLog({ log }: { log: Log }) {
+export default function EditLog({ log }: { log: LogType }) {
   const router = useRouter();
 
   const [title, setTitle] = useState(log.title);
   const [content, setContent] = useState(log.content);
   const [tagsText, setTagsText] = useState((log.tags || []).join(', '));
+  const [format, setFormat] = useState<'plain' | 'markdown'>(log.format ?? 'plain');
   const [loading, setLoading] = useState(false);
   const [showPreview, setShowPreview] = useState(false);
   const [confirmOpen, setConfirmOpen] = useState(false);
@@ -69,6 +72,7 @@ export default function EditLog({ log }: { log: Log }) {
           tags: parseTags(tagsText),
           createdAt,
           updatedAt: now,
+          format,
         });
       } catch (e) {
         console.warn('auto save failed', e);
@@ -80,7 +84,14 @@ export default function EditLog({ log }: { log: Log }) {
         window.clearTimeout(saveTimerRef.current);
       }
     };
-  }, [title, content, tagsText, tempId]);
+  }, [title, content, tagsText, tempId, format]);
+
+  // フォーマットが plain に変わったらプレビューを自動で閉じる
+  useEffect(() => {
+    if (format !== 'markdown' && showPreview) {
+      setShowPreview(false);
+    }
+  }, [format, showPreview]);
 
   function handleRestoreDraft() {
     try {
@@ -93,6 +104,7 @@ export default function EditLog({ log }: { log: Log }) {
       if (found.title !== undefined) setTitle(found.title);
       if (found.content !== undefined) setContent(found.content);
       if (Array.isArray(found.tags)) setTagsText(found.tags.join(', '));
+      if (found.format) setFormat(found.format);
       setHasLocalDraft(false);
     } catch (e) {
       console.warn('restore failed', e);
@@ -115,6 +127,7 @@ export default function EditLog({ log }: { log: Log }) {
           tags,
           createdAt: getGuestDrafts().find(d => d.tempId === tempId)?.createdAt ?? now,
           updatedAt: now,
+          format,
         });
         router.push(`/logs?open=${tempId}`);
         return;
@@ -123,7 +136,7 @@ export default function EditLog({ log }: { log: Log }) {
       const res = await fetch(`/api/logs/${log._id}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ title, content, tags }),
+        body: JSON.stringify({ title, content, tags, format }),
       });
 
       if (!res.ok) {
@@ -188,7 +201,6 @@ export default function EditLog({ log }: { log: Log }) {
     <main>
       <h1 className="text-2xl font-bold mb-4">ログ編集</h1>
 
-      {/* ローカルストレージに下書きが存在するのに現在表示されている初期ログと内容が異なる場合に表示 */}
       {hasLocalDraft && (
         <div className="mb-4 p-4 bg-yellow-50 border border-yellow-200 rounded">
           <div className="flex items-center justify-between">
@@ -236,7 +248,31 @@ export default function EditLog({ log }: { log: Log }) {
           </div>
 
           <div>
-            <label className="block text-sm mb-1">内容（Markdown対応）</label>
+            <label className="block text-sm mb-1">記法</label>
+            <div className="flex gap-3 items-center mb-2">
+              <label className="inline-flex items-center gap-2">
+                <input
+                  type="radio"
+                  name="format"
+                  value="plain"
+                  checked={format === 'plain'}
+                  onChange={() => setFormat('plain')}
+                />
+                <span>テキスト</span>
+              </label>
+              <label className="inline-flex items-center gap-2">
+                <input
+                  type="radio"
+                  name="format"
+                  value="markdown"
+                  checked={format === 'markdown'}
+                  onChange={() => setFormat('markdown')}
+                />
+                <span>Markdown</span>
+              </label>
+            </div>
+
+            <label className="block text-sm mb-1">内容</label>
             <textarea
               value={content}
               onChange={e => setContent(e.target.value)}
@@ -252,7 +288,7 @@ export default function EditLog({ log }: { log: Log }) {
               value={tagsText}
               onChange={e => setTagsText(e.target.value)}
               className="w-full rounded-md border px-3 py-2"
-              placeholder="nextjs, mongodb"
+              placeholder="タグ１, タグ２..."
             />
           </div>
 
@@ -274,30 +310,37 @@ export default function EditLog({ log }: { log: Log }) {
               削除
             </button>
 
-            <button type="button" onClick={handleCancel} className="px-4 py-2 border rounded-md">
+            <button type="button" onClick={handleCancel} className="px-3 py-1 border rounded-md">
               キャンセル
             </button>
 
-            <button
-              type="button"
-              onClick={() => setShowPreview(s => !s)}
-              className="px-3 py-1 border rounded-md"
-            >
-              {showPreview ? 'プレビューを隠す' : 'プレビューを表示'}
-            </button>
+            {/* プレビューボタン（Markdown 選択時のみ表示） */}
+            {format === 'markdown' && (
+              <button
+                type="button"
+                onClick={() => setShowPreview(s => !s)}
+                className="px-3 py-1 border rounded-md"
+              >
+                {showPreview ? 'プレビューを閉じる' : 'プレビューを表示'}
+              </button>
+            )}
           </div>
         </form>
 
-        {showPreview && (
+        {showPreview && format === 'markdown' && (
           <div className="bg-white rounded-lg p-6 shadow">
             <div className="flex items-center justify-between mb-3">
               <h2 className="text-lg font-semibold">プレビュー</h2>
               <span className="text-sm text-gray-500">Markdown 表示</span>
             </div>
 
-            <article className="prose max-w-none">
-              <h3>{title || 'タイトルのプレビュー'}</h3>
-              <ReactMarkdown>{content || '内容のプレビュー（Markdown対応）'}</ReactMarkdown>
+            <article className="prose article-prose max-w-none">
+              <h3>{title || '（タイトル）'}</h3>
+
+              <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                {content || '（Markdown本文）'}
+              </ReactMarkdown>
+
               <div className="mt-3">
                 {parseTags(tagsText).map(t => (
                   <span key={t} className="text-xs bg-gray-100 px-2 py-1 mr-2 rounded">

--- a/src/components/LogModal.tsx
+++ b/src/components/LogModal.tsx
@@ -1,6 +1,7 @@
 'use client';
 import React from 'react';
 import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
 import { useRouter } from 'next/navigation';
 
 export type LogType = {
@@ -9,6 +10,7 @@ export type LogType = {
   content: string;
   date: string;
   tags: string[];
+  format?: 'plain' | 'markdown';
   _isGuest?: boolean;
 };
 
@@ -23,7 +25,8 @@ export default function LogModal({ log, open, onClose, onRequestDelete }: Props)
   const router = useRouter();
   if (!open || !log) return null;
 
-  const currentLog = log as LogType;
+  const currentLog = log;
+  const format = currentLog.format ?? 'plain';
 
   const handleEdit = () => {
     onClose();
@@ -90,8 +93,16 @@ export default function LogModal({ log, open, onClose, onRequestDelete }: Props)
           </div>
         </div>
 
-        <div className="p-6 prose max-w-none">
-          <ReactMarkdown>{currentLog.content || '*内容が空です*'}</ReactMarkdown>
+        <div className="p-6 max-w-none">
+          {format === 'markdown' ? (
+            <article className="prose article-prose max-w-none">
+              <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                {currentLog.content || '*内容が空です*'}
+              </ReactMarkdown>
+            </article>
+          ) : (
+            <div style={{ whiteSpace: 'pre-wrap' }}>{currentLog.content || '内容が空です'}</div>
+          )}
         </div>
       </div>
     </div>

--- a/src/hooks/useAutoSaveDraft.tsx
+++ b/src/hooks/useAutoSaveDraft.tsx
@@ -4,7 +4,7 @@ import { GuestDraft, saveGuestDraft } from '@/lib/guestStorage';
 
 type UseAutoSaveParams = {
   key?: string;
-  data: { title?: string; content?: string; tags?: string[] };
+  data: { title?: string; content?: string; tags?: string[]; format?: 'plain' | 'markdown' };
   delay?: number;
 };
 
@@ -27,6 +27,7 @@ export function useAutoSaveDraft({ key, data, delay = 600 }: UseAutoSaveParams) 
         title: data.title,
         content: data.content,
         tags: data.tags,
+        format: data.format ?? 'plain',
         createdAt: now,
         updatedAt: now,
       };
@@ -39,5 +40,5 @@ export function useAutoSaveDraft({ key, data, delay = 600 }: UseAutoSaveParams) 
 
     return () => clearTimeout(handler);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [data.title, data.content, JSON.stringify(data.tags)]);
+  }, [data.title, data.content, JSON.stringify(data.tags), data.format]);
 }

--- a/src/lib/__tests__/guestStorage.test.ts
+++ b/src/lib/__tests__/guestStorage.test.ts
@@ -6,6 +6,8 @@ import {
   clearGuestDrafts,
   createGuestDraft,
   hasGuestDrafts,
+  buildMergePayload,
+  type GuestDraft,
 } from '@/lib/guestStorage';
 
 describe('guestStorage', () => {
@@ -13,40 +15,71 @@ describe('guestStorage', () => {
     localStorage.clear();
   });
 
-  it('createGuestDraft returns a draft and it is stored', () => {
+  it('createGuestDraft returns a draft and it is stored with default format "plain"', () => {
     const d = createGuestDraft({ title: 't1', content: 'c1', tags: ['a'] });
     const all = getGuestDrafts();
-    expect(all.length).toBe(1);
+    expect(all).toHaveLength(1);
     expect(all[0].tempId).toBe(d.tempId);
     expect(all[0].title).toBe('t1');
+    expect(all[0].content).toBe('c1');
+    expect(all[0].tags).toEqual(['a']);
+    expect(all[0].format).toBe('plain'); // デフォルト
     expect(hasGuestDrafts()).toBe(true);
+    expect(typeof all[0].createdAt).toBe('string');
+    expect(typeof all[0].updatedAt).toBe('string');
   });
 
-  it('saveGuestDraft upserts draft (update path)', () => {
+  it('createGuestDraft accepts explicit format and buildMergePayload includes format', () => {
+    const d = createGuestDraft({ title: 'm', content: 'md', tags: [], format: 'markdown' });
+    expect(d.format).toBe('markdown');
+
+    const payload = buildMergePayload();
+    expect(payload).toHaveProperty('drafts');
+    expect(Array.isArray(payload.drafts)).toBe(true);
+    const first = payload.drafts[0];
+    expect(first).toHaveProperty('tempId', d.tempId);
+    expect(first).toHaveProperty('content', 'md');
+    expect(first).toHaveProperty('format', 'markdown');
+  });
+
+  it('saveGuestDraft upserts draft (update path) and preserves createdAt', () => {
     const d = createGuestDraft({ title: 'orig', content: 'o', tags: [] });
-    const updated = saveGuestDraft({ ...d, title: 'updated' });
+    const originalCreatedAt = d.createdAt;
+    const updatedInput: GuestDraft = { ...d, title: 'updated' };
+    const updated = saveGuestDraft(updatedInput);
     const all = getGuestDrafts();
-    expect(all.length).toBe(1);
+    expect(all).toHaveLength(1);
     expect(all[0].title).toBe('updated');
-    expect(updated.createdAt).toBeDefined();
-    expect(updated.updatedAt).toBeDefined();
+    expect(typeof updated.createdAt).toBe('string');
+    expect(typeof updated.updatedAt).toBe('string');
+    expect(updated.createdAt).toBe(originalCreatedAt);
+    expect(new Date(updated.updatedAt!).getTime()).toBeGreaterThanOrEqual(
+      new Date(updated.createdAt!).getTime()
+    );
   });
 
   it('removeGuestDraft removes the right draft', () => {
     const a = createGuestDraft({ title: 'a', content: '', tags: [] });
     const b = createGuestDraft({ title: 'b', content: '', tags: [] });
-    expect(getGuestDrafts().length).toBe(2);
+    expect(getGuestDrafts()).toHaveLength(2);
     removeGuestDraft(a.tempId);
     const left = getGuestDrafts();
-    expect(left.length).toBe(1);
+    expect(left).toHaveLength(1);
     expect(left[0].tempId).toBe(b.tempId);
   });
 
   it('clearGuestDrafts clears all', () => {
     createGuestDraft({ title: 'a', content: '', tags: [] });
     createGuestDraft({ title: 'b', content: '', tags: [] });
-    expect(getGuestDrafts().length).toBe(2);
+    expect(getGuestDrafts()).toHaveLength(2);
     clearGuestDrafts();
-    expect(getGuestDrafts().length).toBe(0);
+    expect(getGuestDrafts()).toHaveLength(0);
+  });
+
+  it('getGuestDrafts returns empty array when localStorage contains invalid JSON', () => {
+    localStorage.setItem('notearc_guest_drafts_v1', 'this-is-not-json');
+    const drafts = getGuestDrafts();
+    expect(Array.isArray(drafts)).toBe(true);
+    expect(drafts).toHaveLength(0);
   });
 });

--- a/src/lib/guestStorage.ts
+++ b/src/lib/guestStorage.ts
@@ -5,18 +5,45 @@ export type GuestDraft = {
   tags?: string[];
   createdAt?: string;
   updatedAt?: string;
+  format?: 'plain' | 'markdown';
 };
 
 const STORAGE_KEY = 'notearc_guest_drafts_v1';
+
+function safeParse<T>(raw: string | null): T | null {
+  try {
+    if (!raw) return null;
+    return JSON.parse(raw) as T;
+  } catch (e) {
+    console.warn('safeParse failed', e);
+    return null;
+  }
+}
 
 export function getGuestDrafts(): GuestDraft[] {
   if (typeof window === 'undefined') return [];
   try {
     const raw = localStorage.getItem(STORAGE_KEY);
-    if (!raw) return [];
-    const parsed = JSON.parse(raw);
+    const parsed = safeParse<unknown>(raw);
+    if (!parsed) return [];
     if (!Array.isArray(parsed)) return [];
-    return parsed as GuestDraft[];
+    return parsed
+      .map(item => {
+        if (item && typeof item === 'object') {
+          const obj = item as Partial<GuestDraft>;
+          return {
+            tempId: typeof obj.tempId === 'string' ? obj.tempId : `guest-${Date.now()}`,
+            title: typeof obj.title === 'string' ? obj.title : undefined,
+            content: typeof obj.content === 'string' ? obj.content : undefined,
+            tags: Array.isArray(obj.tags) ? (obj.tags as string[]) : undefined,
+            createdAt: typeof obj.createdAt === 'string' ? obj.createdAt : undefined,
+            updatedAt: typeof obj.updatedAt === 'string' ? obj.updatedAt : undefined,
+            format: obj.format === 'plain' || obj.format === 'markdown' ? obj.format : undefined,
+          } as GuestDraft;
+        }
+        return null;
+      })
+      .filter(Boolean) as GuestDraft[];
   } catch (e) {
     console.warn('getGuestDrafts parse failed', e);
     return [];
@@ -26,7 +53,11 @@ export function getGuestDrafts(): GuestDraft[] {
 export function saveGuestDraft(draft: GuestDraft): GuestDraft {
   if (typeof window === 'undefined') return draft;
   const now = new Date().toISOString();
-  const d = { ...draft, updatedAt: draft.updatedAt ?? now, createdAt: draft.createdAt ?? now };
+  const d: GuestDraft = {
+    ...draft,
+    updatedAt: draft.updatedAt ?? now,
+    createdAt: draft.createdAt ?? now,
+  };
   const all = getGuestDrafts();
   const idx = all.findIndex(x => x.tempId === d.tempId);
   if (idx >= 0) {
@@ -34,7 +65,11 @@ export function saveGuestDraft(draft: GuestDraft): GuestDraft {
   } else {
     all.unshift(d);
   }
-  localStorage.setItem(STORAGE_KEY, JSON.stringify(all));
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(all));
+  } catch (e) {
+    console.warn('saveGuestDraft failed to write localStorage', e);
+  }
   return d;
 }
 
@@ -42,6 +77,7 @@ export function createGuestDraft(input: {
   title?: string;
   content?: string;
   tags?: string[];
+  format?: 'plain' | 'markdown';
 }): GuestDraft {
   const tempId = `guest-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
   const now = new Date().toISOString();
@@ -52,6 +88,7 @@ export function createGuestDraft(input: {
     tags: input.tags ?? [],
     createdAt: now,
     updatedAt: now,
+    format: input.format ?? 'plain',
   };
   saveGuestDraft(draft);
   return draft;
@@ -85,6 +122,7 @@ export function buildMergePayload() {
     tags: d.tags ?? [],
     updatedAt: d.updatedAt,
     createdAt: d.createdAt,
+    format: d.format,
   }));
   return { drafts };
 }

--- a/src/models/Log.ts
+++ b/src/models/Log.ts
@@ -1,11 +1,14 @@
 import mongoose, { Schema, Document, Model } from 'mongoose';
 
+export type LogFormat = 'plain' | 'markdown';
+
 export interface ILog extends Document {
   title: string;
   content: string;
   date: Date;
   tags: string[];
   userId: string;
+  format: LogFormat;
   createdAt?: Date;
   updatedAt?: Date;
   guestTempId?: string;
@@ -19,6 +22,12 @@ const LogSchema = new Schema<ILog>(
     tags: [{ type: String }],
     userId: { type: String, required: true, index: true },
     guestTempId: { type: String, required: false, index: true },
+    format: {
+      type: String,
+      enum: ['plain', 'markdown'],
+      default: 'plain',
+      required: true,
+    },
   },
   { timestamps: true }
 );

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,5 +4,8 @@ export type Log = {
   content: string;
   date: string;
   tags: string[];
+  format: 'plain' | 'markdown';
   folderId?: string;
+  userId?: string;
+  _isGuest?: boolean;
 };

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,11 +5,22 @@ export default defineConfig({
   plugins: [tsconfigPaths()],
   test: {
     globals: true,
-    environment: 'jsdom', // React コンポーネントをテスト
+    environment: 'jsdom',
     setupFiles: ['./src/test/setupTests.ts'],
     coverage: {
       provider: 'v8',
-      reporter: ['text', 'html'],
+      reporter: ['text', 'lcov', 'html'],
+      exclude: [
+        '.next/**',
+        'next.config.*',
+        'postcss.config.*',
+        'eslint.config.*',
+        'vitest.config.*',
+        'next-env.d.*',
+        'docker/**',
+        'notearc/docker/**',
+        'src/types/**',
+      ],
     },
   },
 });


### PR DESCRIPTION
下記のファイルを修正し、ログ作成/編集時のmarkdown記法以外の方法を追加した。
src/app/api/guest/merge/route.ts
src/app/api/logs/[id]/route.ts
src/app/api/logs/route.ts
src/app/globals.css
src/app/logs/edit/[id]/page.tsx
src/app/logs/new/page.tsx
src/app/logs/page.tsx
src/components/EditLog.tsx
src/components/LogModal.tsx
src/hooks/useAutoSaveDraft.tsx
src/lib/__tests__/guestStorage.test.ts
src/lib/guestStorage.ts
src/models/Log.ts
src/types/index.ts
vitest.config.ts